### PR TITLE
Move numpy before biopython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
+numpy==1.12.1
 biopython==1.69
 Django==1.11
 djangorestframework==3.6.2
 dynamic-rest==1.6.6
 lxml==3.7.3
-numpy==1.12.1
 nose==1.3.7
 pandas==0.20.1
 pytest>=2.9.2


### PR DESCRIPTION
biopython requires numpy for full functionality so should be installed after it by requirements